### PR TITLE
Add workflows for automatic testing on `pushe` & `pr`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: action/setup-go@v4
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ on:
             go-version: '1.21'
 
         - name: Test
-            run: go test -v .
+          run: go test -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,17 @@ on:
 
 
 jobs:
-    build:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Set up repository
-        - uses: actions/checkout@v3
+  test:
 
-        - name: Set up Go
-          uses: action/setup-go@v4
-          with:
-            go-version: '1.21'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v3
 
-        - name: Launch Tests
-          run: go test -v .
+      - name: Set up Go
+        uses: action/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Launch Tests
+        run: go test -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+
+
+        - name: Set up Go
+          uses: action/setup-go@v4
+          with:
+            go-version: '1.21'
+
+        - name: Test
+            run: go test -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: '1.21'
+          cache: false # optional, default is true
 
       - name: Launch Tests
         run: go test -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,17 @@ on:
     branches: ["main"]
 
 
-  jobs:
+jobs:
     build:
       runs-on: ubuntu-latest
       steps:
+        - name: Set up repository
         - uses: actions/checkout@v3
-
 
         - name: Set up Go
           uses: action/setup-go@v4
           with:
             go-version: '1.21'
 
-        - name: Test
+        - name: Launch Tests
           run: go test -v .

--- a/num2let_test.go
+++ b/num2let_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"testing"
+)
+
+type testSuit struct {
+	input int; expected string
+}
+
+func TestSingleDigit(t *testing.T) {
+	tests := []testSuit {
+		{0, "zéro"},
+		{1, "un"},
+		{2, "deux"},
+		{3, "trois"},
+		{4, "quatre"},
+		{5, "cinq"},
+		{6, "six"},
+		{7, "sept"},
+		{8, "huit"},
+		{9, "neuf"},
+	}
+
+	test(tests,t)
+}
+
+
+
+func TestMultiplesOfTen(t *testing.T) {
+	tests := []testSuit{
+		{10, "dix"},
+		{20, "vingt"},
+		{30, "trente"},
+		{40, "quarante"},
+		{50, "cinquante"},
+		{60, "soixante"},
+		{70, "soixante-dix"},
+		{80, "quatre-vingts"},
+		{90, "quatre-vingt-dix"},
+	}
+
+	test(tests,t)
+}
+
+func TestTeens(t *testing.T) {
+	tests := []testSuit{
+		{11, "onze"},
+		{12, "douze"},
+		{13, "treize"},
+		{14, "quatorze"},
+		{15, "quinze"},
+		{16, "seize"},
+		{17, "dix-sept"},
+		{18, "dix-huit"},
+		{19, "dix-neuf"},
+	}
+
+	test(tests,t)
+}
+
+func TestTwoDigitNumbers(t *testing.T) {
+	tests := []testSuit{
+		{21, "vingt et un"},
+		{34, "trente-quatre"},
+		{48, "quarante-huit"},
+		{57, "cinquante-sept"},
+		{69, "soixante-neuf"},
+		{73, "soixante-treize"},
+		{88, "quatre-vingt-huit"},
+		{94, "quatre-vingt-quatorze"},
+	}
+
+	test(tests,t)
+}
+
+func TestThreeDigitNumbers(t *testing.T) {
+	tests := []testSuit{
+		{100, "cent"},
+		{234, "deux cent trente-quatre"},
+		{567, "cinq cent soixante-sept"},
+		{789, "sept cent quatre-vingt-neuf"},
+		{911, "neuf cent onze"},
+		{999, "neuf cent quatre-vingt-dix-neuf"},
+	}
+
+	test(tests,t)
+}
+
+func TestFourDigitNumbers(t *testing.T) {
+	tests := []testSuit{
+		{1000, "mille"},
+		{2001, "deux mille un"},
+		{3456, "trois mille quatre cent cinquante-six"},
+		{6789, "six mille sept cent quatre-vingt-neuf"},
+		{9123, "neuf mille cent vingt-trois"},
+		{9999, "neuf mille neuf cent quatre-vingt-dix-neuf"},
+	}
+
+	test(tests,t)
+}
+
+// Todo add support for 1_000_000_000 numbers
+func TestLargeNumbers(t *testing.T) {
+	tests := []testSuit{
+		{10000, "dix mille"},
+		{56789, "cinquante-six mille sept cent quatre-vingt-neuf"},
+		{123456, "cent vingt-trois mille quatre cent cinquante-six"},
+		{789012, "sept cent quatre-vingt-neuf mille douze"},
+		{1000000, "un million"},
+		{9876543, "neuf millions huit cent soixante-seize mille cinq cent quarante-trois"},
+		// {1000000000, "un milliard"},
+		// {1234567890, "un milliard deux cent trente-quatre million cinq cent soixante-sept mille huit cent quatre-vingt-dix"},
+	}
+	test(tests,t)
+}
+
+func test(values []testSuit,t *testing.T) {
+	for _, test := range values {
+		t.Run("", func(t *testing.T) {
+			result := simpleNumber(test.input)
+			if result != test.expected {
+				t.Errorf("For input %d, expected %s, but got %s", test.input, test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add a workflow that will automatically run test on `push` & `pull_request`
- Fix `test.yml` on line `23`
- Fix `jobs` is not a valid event name
- Fix every step must define a `uses` or `run` key
- Add `workflow_dispatch` event to `test.yml`
- Fix typo in line 22
- Update `actions/checkout@v3`, `actions/setup-go@v4` to use Node.js 20 Disable cache in `actions/setup-go`
- Add a test file
